### PR TITLE
fix: include XIB resources in iOS podspec to prevent crash

### DIFF
--- a/ios/flutter_uae_pass.podspec
+++ b/ios/flutter_uae_pass.podspec
@@ -13,8 +13,8 @@ A new Flutter plugin project.
   s.license          = { :file => '../LICENSE' }
   s.author           = { 'Your Company' => 'email@example.com' }
   s.source           = { :path => '.' }
-  s.source_files = 'Classes/**/*'
-
+  s.source_files = 'Classes/**/*.{swift,h,m}'
+  s.resources = 'Classes/**/*.xib'
 
   s.dependency 'Flutter'
   s.platform = :ios, '13.0'


### PR DESCRIPTION
This PR fixes a critical crash on iOS when users attempt to authenticate with UAE Pass. The crash occurs because the podspec does not bundle the required XIB file for the WebView authentication modal.

**Problem**
When tapping the UAE Pass authentication button on iOS, the app crashes immediately because UAEPassWebViewController.xib is not included in the framework bundle. While the XIB file exists in the repository (ios/Classes/ViewControllers/UAEPassWebViewController.xib), CocoaPods does not automatically bundle it as a resource.

**Current behavior:**
App crashes when UAE Pass button is tapped
Error: Unable to load NIB/XIB file

**Expected behavior:**
Authentication modal should display
User can complete UAE Pass authentication flow

**Solution**
Updated `ios/flutter_uae_pass.podspec` to explicitly bundle XIB resources:

**Changes:**
Made source_files more specific (swift, h, m files only)
Added s.resources to include XIB interface files
